### PR TITLE
🛠️  add Dockerfile for screenshot-updates and detail how to run it in README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM mcr.microsoft.com/playwright:v1.34.0-jammy
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt purge nodejs -y
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - 
+RUN apt-get install -y nodejs

--- a/README.md
+++ b/README.md
@@ -72,6 +72,6 @@ then you can build the Dockerfile:
 and to save the screenshots, run:
 `docker run --rm --network host -v $(pwd):/work/ -w /work/ -it screenshot-update /bin/bash` (pwd would evaluate to your current working directory, so make sure you are at the root of the application directory)
 Now you are connected to the docker container, to save the screenshots, run:
-`lerna run test:screenshots:update`
+`node_modules/.bin/lerna run test:screenshots:update`
 if you wish to test it as well:
-`lerna run test:screenshots`
+`node_modules/.bin/lerna run test:screenshots`

--- a/README.md
+++ b/README.md
@@ -61,3 +61,17 @@ Default.paramters = {
     },
   }
 ```
+# Updating screenshots on a linux-based system
+As the app is eventually tested and deployed in a Linux environment, we need to update the screenshots in the same platform
+to do that, first make sure to:
+- run `npm install` on your own local machine
+- run `lerna bootstrap` on your own local machine
+
+then you can build the Dockerfile:
+`docker build -t screenshot-update`
+and to save the screenshots, run:
+`docker run --rm --network host -v $(pwd):/work/ -w /work/ -it screenshot-update /bin/bash` (pwd would evaluate to your current working directory, so make sure you are at the root of the application directory)
+Now you are connected to the docker container, to save the screenshots, run:
+`lerna run test:screenshots:update`
+if you wish to test it as well:
+`lerna run test:screenshots`


### PR DESCRIPTION
### Problem
Currently the screenshots are done via MacOS, while the automated tests run in Ubuntu  (The app also runs in debian-based system eventually), this leads to some inconsistencies with the tests.

This PR serves to add a dockerfile that would be used locally to generate those screenshots
this uses playwright image based on jammy ubuntu (ubuntu 22.04 LTS)
only hack we do is we remove the LTS node (18) and install node 14 (deprecated one), this is because our app depends on that.

the rest of the needed tasks are done on one's own machine
